### PR TITLE
Updated url from api.applivery.io to upload.applivery.io

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -103,7 +103,7 @@ curl_cmd="$curl_cmd -F \"deployer.info.buildUrl=${buildUrl}\""
 curl_cmd="$curl_cmd -F \"deployer.info.ciUrl=${ciUrl}\""
 curl_cmd="$curl_cmd -F \"deployer.info.repositoryUrl=${repositoryUrl}\""
 curl_cmd="$curl_cmd -F \"deployer.info.buildNumber=${buildNumber}\""
-curl_cmd="$curl_cmd https://api.applivery.io/v1/integrations/builds"
+curl_cmd="$curl_cmd https://upload.applivery.io/v1/integrations/builds"
 
 echo
 echo "=> Curl:"


### PR DESCRIPTION
Changed the base url which was already done for the iOS repository, but not for the android repository.
See: https://github.com/applivery/steps-applivery-ios-deploy/commit/3d5f6e737d3ed2593cbb6685994fc8fb61bf0f84